### PR TITLE
Bug wdp190203 2

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in the repo.
+*       @Varenthein @xkxd @OskarLebuda @stepek

--- a/src/index.html
+++ b/src/index.html
@@ -20,6 +20,7 @@
     <module href="./src/partials/90_footer.html"></module>
 
     <script src="./scripts/bootstrap.min.js"></script>
+    <script src="./scripts/cart.count.js"></script>
     <script src="./scripts/app.js"></script>
   </body>
 </html>

--- a/src/sass/components/_header.scss
+++ b/src/sass/components/_header.scss
@@ -85,9 +85,9 @@ header {
             margin-right: 5px;
           }
         }
-
         .cart-counter {
-          width: 28px;
+          min-width: 28px;
+          padding: 0 4px;
           height: 27px;
           border-radius: 14px;
           background-color: $header-bg;

--- a/src/sass/components/_header.scss
+++ b/src/sass/components/_header.scss
@@ -80,7 +80,7 @@ header {
           align-items: center;
           justify-content: center;
           font-size: 20px;
-
+          position: relative;
           i {
             margin-right: 5px;
           }
@@ -98,8 +98,9 @@ header {
           color: rgb(224, 227, 237);
           position: absolute;
           top: 50%;
-          right: 0;
-          transform: translate(50%, -50%);
+          left: 70%;
+          transform: translate(0%, -50%);
+          font-size: 14px;
         }
 
         &:hover {

--- a/src/scripts/cart.count.js
+++ b/src/scripts/cart.count.js
@@ -2,29 +2,6 @@
 
 const shoppingCartCounter = document.querySelector('.cart-counter');
 
-// Opcja z ingerencją w style CSS, określająca max. wskaźnik
 if (shoppingCartCounter.innerText > 99999) {
   shoppingCartCounter.innerHTML = 99999;
 }
-
-/* Opcja w pełni JS, bez ingerencji w style CSS
-function adjustCartCounterDisplay () {
-  let shoppingCartItemsCount = shoppingCartCounter.innerText.length;
-
-  if (shoppingCartItemsCount < 4) {
-    shoppingCartCounter.style.fontSize = '13px';
-  } else if (shoppingCartItemsCount > 3 && shoppingCartItemsCount < 5) {
-    shoppingCartCounter.style.fontSize = '9px';
-    shoppingCartCounter.style.paddingTop = '3px';
-  } else if (shoppingCartItemsCount === 5) {
-    shoppingCartCounter.style.fontSize = '8px';
-    shoppingCartCounter.style.paddingTop = '4px';
-  } else if (shoppingCartItemsCount > 5) {
-    shoppingCartCounter.innerHTML = '...';
-    shoppingCartCounter.style.paddingBottom = '3px';
-    shoppingCartCounter.style.color = 'rgb(187, 0, 0)';
-  }
-}
-
-shoppingCartCounter.addEventListener('change', adjustCartCounterDisplay());
-*/

--- a/src/scripts/cart.count.js
+++ b/src/scripts/cart.count.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const shoppingCartCounter = document.querySelector('.cart-counter');
+
+function adjustCartCounterDisplay () {
+  let shoppingCartItemsCount = shoppingCartCounter.innerText.length;
+
+  if (shoppingCartItemsCount < 4) {
+    shoppingCartCounter.style.fontSize = '13px';
+  } else if (shoppingCartItemsCount > 3 && shoppingCartItemsCount < 5) {
+    shoppingCartCounter.style.fontSize = '9px';
+    shoppingCartCounter.style.paddingTop = '3px';
+  } else if (shoppingCartItemsCount === 5) {
+    shoppingCartCounter.style.fontSize = '8px';
+    shoppingCartCounter.style.paddingTop = '4px';
+  } else if (shoppingCartItemsCount > 5) {
+    shoppingCartCounter.innerHTML = '...';
+    shoppingCartCounter.style.paddingBottom = '3px';
+    shoppingCartCounter.style.color = 'rgb(187, 0, 0)';
+  }
+}
+
+shoppingCartCounter.addEventListener('change', adjustCartCounterDisplay());

--- a/src/scripts/cart.count.js
+++ b/src/scripts/cart.count.js
@@ -2,6 +2,12 @@
 
 const shoppingCartCounter = document.querySelector('.cart-counter');
 
+// Opcja z ingerencją w style CSS, określająca max. wskaźnik
+if (shoppingCartCounter.innerText > 99999) {
+  shoppingCartCounter.innerHTML = 99999;
+}
+
+/* Opcja w pełni JS, bez ingerencji w style CSS
 function adjustCartCounterDisplay () {
   let shoppingCartItemsCount = shoppingCartCounter.innerText.length;
 
@@ -21,3 +27,4 @@ function adjustCartCounterDisplay () {
 }
 
 shoppingCartCounter.addEventListener('change', adjustCartCounterDisplay());
+*/


### PR DESCRIPTION
Cel:
- poprawa wyświetlania stanu koszyka w przypadku liczby większej niż 3 cyfrowej
- poprawne wyświetlanie wartości od 0-99999

Rozwiązanie: (dwa rozwiązania - jedno w pełni JS drugie CSS/JS)
1. Dodanie skryptu cart.count.js - sprawdzenie długości wskaźnika ilości produktów, w zależności od długości wartości, font jest zmniejszany i przy wartościach powyżej 9999, ustawienie  z góry wartości

2. Dodanie styli CSS, kierujących tekst w prawą stronę (zamiana pozycjonowania z right na left) + dodanie skryptu sprawdzającego czy wartość nie jest większa niż 99999.

Review: 
Review: @Varenthein @xkxd @OskarLebuda @stepek @bsopecki @AleksandraDworak
(nie mam listy do review jak w github --help)