### PR TITLE
WDP190203-11

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in the repo.
+*       @Varenthein @xkxd @OskarLebuda @stepek

--- a/src/index.html
+++ b/src/index.html
@@ -21,5 +21,6 @@
 
     <script src="./scripts/bootstrap.min.js"></script>
     <script src="./scripts/app.js"></script>
+    <script src="./scripts/header.js"></script>
   </body>
 </html>

--- a/src/partials/10_header.html
+++ b/src/partials/10_header.html
@@ -66,6 +66,20 @@
               <button><i class="fa fa-search"></i></button>
             </div>
           </form>
+          <div class="menu-button">
+            <a href="#"><i class="fas fa-bars menu-button-dropdown"></i></a>
+          </div>
+        </div>
+        <div class="dropdown-menu">
+          <ul>
+            <li><a href="#" class="active">Home</a></li>
+            <li><a href="#">Furniture</a></li>
+            <li><a href="#">Chair</a></li>
+            <li><a href="#">Table</a></li>
+            <li><a href="#">Sofa</a></li>
+            <li><a href="#">Bedroom</a></li>
+            <li><a href="#">Blog</a></li>
+          </ul>
         </div>
         <div class="col-auto menu">
           <ul>

--- a/src/partials/50_section-products.html
+++ b/src/partials/50_section-products.html
@@ -46,6 +46,7 @@
               <a href="#" class="btn-outline"><i class="far fa-heart"></i></a>
               <a href="#" class="btn-outline"><i class="fas fa-exchange-alt"></i></a>
             </div>
+            <div class="old-price"></div>
             <div class="price"><div class="btn-main-small no-hover">$ 30.00</div></div>
           </div>
         </div>
@@ -74,6 +75,7 @@
               <a href="#" class="btn-outline"><i class="far fa-heart"></i></a>
               <a href="#" class="btn-outline"><i class="fas fa-exchange-alt"></i></a>
             </div>
+            <div class="old-price"></div>
             <div class="price"><div class="btn-main-small no-hover">$ 30.00</div></div>
           </div>
         </div>
@@ -102,6 +104,7 @@
               <a href="#" class="btn-outline"><i class="far fa-heart"></i></a>
               <a href="#" class="btn-outline"><i class="fas fa-exchange-alt"></i></a>
             </div>
+            <div class="old-price show-price">$35.00</div>
             <div class="price"><div class="btn-main-small no-hover">$ 30.00</div></div>
           </div>
         </div>
@@ -130,6 +133,7 @@
               <a href="#" class="btn-outline"><i class="far fa-heart"></i></a>
               <a href="#" class="btn-outline"><i class="fas fa-exchange-alt"></i></a>
             </div>
+            <div class="old-price show-price">$20.00</div>
             <div class="price"><div class="btn-main-small no-hover">$ 30.00</div></div>
           </div>
         </div>
@@ -158,6 +162,7 @@
               <a href="#" class="btn-outline"><i class="far fa-heart"></i></a>
               <a href="#" class="btn-outline"><i class="fas fa-exchange-alt"></i></a>
             </div>
+            <div class="old-price"></div>
             <div class="price"><div class="btn-main-small no-hover">$ 30.00</div></div>
           </div>
         </div>
@@ -186,6 +191,7 @@
               <a href="#" class="btn-outline"><i class="far fa-heart"></i></a>
               <a href="#" class="btn-outline"><i class="fas fa-exchange-alt"></i></a>
             </div>
+            <div class="old-price"></div>
             <div class="price"><div class="btn-main-small no-hover">$ 30.00</div></div>
           </div>
         </div>
@@ -214,6 +220,7 @@
               <a href="#" class="btn-outline"><i class="far fa-heart"></i></a>
               <a href="#" class="btn-outline"><i class="fas fa-exchange-alt"></i></a>
             </div>
+            <div class="old-price show-price">$35.00</div>
             <div class="price"><div class="btn-main-small no-hover">$ 30.00</div></div>
           </div>
         </div>
@@ -242,6 +249,7 @@
               <a href="#" class="btn-outline"><i class="far fa-heart"></i></a>
               <a href="#" class="btn-outline"><i class="fas fa-exchange-alt"></i></a>
             </div>
+            <div class="old-price show-price">$20.00</div>
             <div class="price"><div class="btn-main-small no-hover">$ 30.00</div></div>
           </div>
         </div>

--- a/src/sass/_variables.scss
+++ b/src/sass/_variables.scss
@@ -7,5 +7,6 @@ $footer-bg: #363636;
 $primary: #d58e32;
 
 $text-color: #2a2a2a;
+$old-price-color: #a5a5a5;
 
 $form-border-color: #292929;

--- a/src/sass/components/_header.scss
+++ b/src/sass/components/_header.scss
@@ -117,108 +117,173 @@ header {
 
     .container > .row {
       height: 84px;
+      @include media-breakpoint-between(md, lg) {
+        height: 126px;
+      }
     }
+  }
 
-    .menu {
+  .menu {
+    display: flex;
+    align-self: stretch;
+
+    ul {
+      margin: 0;
+      padding: 0;
       display: flex;
-      align-self: stretch;
 
-      ul {
-        margin: 0;
-        padding: 0;
+      li {
+        list-style: none;
         display: flex;
+        align-items: stretch;
 
-        li {
-          list-style: none;
+        a {
+          color: $text-color;
+          text-transform: uppercase;
+          font-size: 12px;
+          padding: 1rem;
+          text-decoration: none;
           display: flex;
-          align-items: stretch;
+          align-items: center;
+          border-top: 4px solid #ffffff;
+          font-weight: 500;
+          letter-spacing: 1px;
 
-          a {
-            color: $text-color;
-            text-transform: uppercase;
-            font-size: 12px;
-            padding: 1rem;
-            text-decoration: none;
-            display: flex;
-            align-items: center;
-            border-top: 4px solid #ffffff;
-            font-weight: 500;
-            letter-spacing: 1px;
+          &:hover,
+          &.active {
+            background-color: $primary;
+            color: #ffffff;
+            border-color: $primary;
+          }
 
-            &:hover,
-            &.active {
-              background-color: $primary;
-              color: #ffffff;
-              border-color: $primary;
-            }
-
-            &.active {
-              border-color: $text-color;
-            }
+          &.active {
+            border-color: $text-color;
           }
         }
       }
     }
+    @include media-breakpoint-down(lg) {
+      position: absolute;
+      top: 200px;
+    }
+    @include media-breakpoint-down(sm) {
+      display: none;
+    }
+  }
+  .search-form {
+    border: 1px solid $form-border-color;
+    display: inline-flex;
+    height: 45px;
+    color: $text-color;
+    margin: 20px 0;
 
-    .search-form {
-      border: 1px solid $form-border-color;
-      display: inline-flex;
-      height: 45px;
-      color: $text-color;
+    .category {
+      border-right: 1px solid $form-border-color;
+      display: flex;
+      align-items: center;
+      position: relative;
 
-      .category {
-        border-right: 1px solid $form-border-color;
-        display: flex;
-        align-items: center;
-        position: relative;
-
-        i:first-child {
-          color: $primary;
-          position: absolute;
-          left: 10px;
-          z-index: 0;
-        }
-
-        i:last-child {
-          position: absolute;
-          right: 10px;
-          z-index: 0;
-        }
-
-        select {
-          -webkit-appearance: none;
-          border: 0;
-          background-color: transparent;
-          outline: none;
-          padding: 5px 30px 5px 35px;
-          font-size: 14px;
-          position: relative;
-          z-index: 1;
-        }
+      i:first-child {
+        color: $primary;
+        position: absolute;
+        left: 10px;
+        z-index: 0;
       }
 
-      .search-field {
-        display: flex;
-        align-items: center;
+      i:last-child {
+        position: absolute;
+        right: 10px;
+        z-index: 0;
+      }
+
+      select {
+        -webkit-appearance: none;
+        border: 0;
+        background-color: transparent;
+        outline: none;
+        padding: 5px 30px 5px 35px;
+        font-size: 14px;
         position: relative;
+        z-index: 1;
+      }
+    }
 
-        input {
-          border: 0;
-          padding-left: 10px;
-          font-size: 14px;
-          outline: none;
+    .search-field {
+      display: flex;
+      align-items: center;
+      position: relative;
 
-          &::placeholder {
-            color: $text-color;
-          }
+      input {
+        border: 0;
+        padding-left: 10px;
+        font-size: 14px;
+        outline: none;
+
+        &::placeholder {
+          color: $text-color;
         }
+      }
+      button {
+        border: 0;
+        background-color: transparent;
+        outline: none;
+      }
+    }
+    @include media-breakpoint-between(md, lg) {
+      position: relative;
+      margin-top: 60px;
+    }
+  }
+  .menu-button {
+    color: $primary;
+    padding: 10px;
+    margin-left: 10px;
+    display: inline-block;
+    position: static;
+    @include media-breakpoint-up(md) {
+      display: none;
+    }
+  }
+}
+.dropdown-menu {
+  display: none;
+  position: fixed;
+  width: 100%;
 
-        button {
-          border: 0;
-          background-color: transparent;
-          outline: none;
+  ul {
+    margin: 0;
+    padding: 0;
+    background-color: #ffffff;
+    li {
+      list-style: none;
+      a {
+        color: $text-color;
+        text-transform: uppercase;
+        font-size: 12px;
+        padding: 1rem;
+        text-decoration: none;
+        display: block;
+        align-items: center;
+        border-top: 4px solid #ffffff;
+        font-weight: 500;
+        letter-spacing: 1px;
+
+        &:hover,
+        &.active {
+          background-color: $primary;
+          color: #ffffff;
+          border-color: $primary;
+        }
+        &.active {
+          border-color: $text-color;
         }
       }
     }
   }
+}
+.show {
+  display: block;
+  position: relative;
+  top: 10px;
+  margin-top: 10px;
 }

--- a/src/sass/components/_product-box.scss
+++ b/src/sass/components/_product-box.scss
@@ -78,5 +78,19 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
+    .old-price {
+      display: none;
+      justify-content: center;
+      text-align: center;
+      text-decoration: line-through;
+      font-size: 14px;
+      color: $old-price-color;
+      margin-left: 30px;
+      font-family: "Poppins", sans-serif;
+      font-weight: 300;
+      &.show-price {
+        display: flex;
+      }
+    }
   }
 }

--- a/src/scripts/header.js
+++ b/src/scripts/header.js
@@ -1,0 +1,8 @@
+function toggleMenu (visible) {
+  document.querySelector('.dropdown-menu').classList.toggle('show', visible);
+}
+
+document.querySelector('.menu-button-dropdown').addEventListener('click', function (e) {
+  e.preventDefault();
+  toggleMenu();
+});


### PR DESCRIPTION
Strona sypie się w trybach responsive. Klient nie ma designów RWD, więc trzeba zrobić na własną rękę. 
Ten task dotyczy menu głównego (wyszukiwanie i "Home", etc.) 
Na tabletach wyszukiwanie ma być pod menu, a na mniejszych ekranach ma być wyszukiwanie i obok niego ikona mobilnego menu, które po rozwinięciu ma pokazywać dropdown przykrywający treść strony. 

Rozwiązanie:
Dla tabletów menu zastosowano szersze menu - żeby wszystko się mieściło - zgodnie z zadaniem wyszukiwanie jest pod menu

dla mniejszych rozdzielczości menu jest ukrywane - dodano przycisk pokazujący się tylko dla tych rozdzielczości rozwija menu (dodano skrypt obsługujący to zdarzenie).